### PR TITLE
Fix GitHub worflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
+          - ubuntu-18.04
 
     services:
       mysql:
@@ -23,6 +23,7 @@ jobs:
           MYSQL_DATABASE: test_database
         ports:
           - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=10
 
       postgres:
         image: postgres:10.8
@@ -32,6 +33,8 @@ jobs:
           POSTGRES_DB: test_database
         ports:
           - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       - name: Verify MySQL connection from host

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
           MYSQL_DATABASE: test_database
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
       postgres:
         image: postgres:10.8
@@ -33,8 +32,6 @@ jobs:
           POSTGRES_DB: test_database
         ports:
           - 5432:5432
-        # needed because the postgres container does not provide a healthcheck
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       - name: Verify MySQL connection from host

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mariadb:10.5
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_USER: root

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-latest
 
     services:
       mysql:
-        image: mariadb:10.5
+        image: mariadb:10.4
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_USER: root


### PR DESCRIPTION
## Description
Fix github worflow

## Changelist
- Use mariadb 10.4 instead of mysql 5.7
- Raise up `--health-retries` from 3 to 10