### PR TITLE
chore: add php 8.5 to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,13 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    paths-ignore:
-      - '**.md'
   pull_request:
     paths-ignore:
       - '**.md'
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   test:
@@ -26,6 +27,7 @@ jobs:
           - ubuntu-latest
         php-version:
           - '8.4'
+          - '8.5'
 
     steps:
       - name: Checkout
@@ -37,8 +39,12 @@ jobs:
       - name: Build
         run: docker compose build --build-arg PHPVERSION=${{ matrix.php-version }}
 
+      - name: Lint
+        if: matrix.php-version == '8.4'
+        run: docker compose run lib composer lint
+
       - name: Test
-        run: docker compose run -e "PHP_CS_FIXER_IGNORE_ENV=True" lib composer ci
+        run: docker compose run lib composer test
 
       - name: Upload coverage
         uses: codecov/codecov-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN docker-php-ext-install \
 RUN apk add --no-cache \
     $PHPIZE_DEPS \
     linux-headers \
-    && pecl install xdebug-3.4.2 \
+    && pecl install xdebug-3.5.1 \
     && docker-php-ext-enable xdebug \
     && rm -rf /tmp/* /var/cache/apk/*
 

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
             "php-cs-fixer fix -vvv"
         ],
         "test": [
-            "phpunit --colors --coverage-html ./coverage --coverage-clover coverage/clover.xml"
+            "phpunit --colors --display-deprecation --coverage-html ./coverage --coverage-clover coverage/clover.xml"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
             "php-cs-fixer fix -vvv"
         ],
         "test": [
-            "phpunit --colors --display-deprecation --coverage-html ./coverage --coverage-clover coverage/clover.xml"
+            "phpunit --colors --display-all-issues --coverage-html ./coverage --coverage-clover coverage/clover.xml"
         ]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "rancoud/database",
-            "version": "7.0.1",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Database.git",
-                "reference": "13954b99d25834cd1dd34a6f4a95c1692e359a18"
+                "reference": "4ac7ba682256798b6a0a7f236d0517f4a61836ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Database/zipball/13954b99d25834cd1dd34a6f4a95c1692e359a18",
-                "reference": "13954b99d25834cd1dd34a6f4a95c1692e359a18",
+                "url": "https://api.github.com/repos/rancoud/Database/zipball/4ac7ba682256798b6a0a7f236d0517f4a61836ba",
+                "reference": "4ac7ba682256798b6a0a7f236d0517f4a61836ba",
                 "shasum": ""
             },
             "require": {
@@ -52,9 +52,9 @@
             "description": "Database package",
             "support": {
                 "issues": "https://github.com/rancoud/Database/issues",
-                "source": "https://github.com/rancoud/Database/tree/7.0.1"
+                "source": "https://github.com/rancoud/Database/tree/7.0.2"
             },
-            "time": "2026-03-15T11:54:21+00:00"
+            "time": "2026-05-31T17:54:16+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
Here are some tips for you:  
1. If this PR is still in in Progress, put it in draft.
2. If this PR is introducing a breaking change please prefix with *BREAKING* in PR title.
3. If this PR has any follow up tasks, please prefix with *TODO* and describe follow up task.
4. When PR is ready to be reviewed, please tag rancoud as a sole reviewer.
-->
# Description
* add php 8.5 to test workflow
* avoid double run on github action
* add `--display-all-issues` on phpunit command
* remove lint action on php 8.5
* remove `PHP_CS_FIXER_IGNORE_ENV=True` for lint
* update dependency `rancoud/database` from 7.0.1 to 7.0.2